### PR TITLE
Add support for ES6 import syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,4 +69,6 @@ class ReadlineTransform extends Transform {
   }
 }
 
+ReadlineTransform.ReadlineTransform = ReadlineTransform;
+
 module.exports = ReadlineTransform;


### PR DESCRIPTION
Hi, would you consider to add a possibility to use this syntax for import?

```js
import { ReadlineTransform } from 'readline-transform';
```

Additionally I plan to add some typings for TypeScript so this syntax for imports is more natural.

Thanks!
