### PR TITLE
Fix test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,9 +18,9 @@ describe('ReadlineTransform', () => {
 
       readStream.pipe(transform).pipe(writeStream);
 
-      readStream.write(new Buffer('foo\nba'));
-      readStream.write(new Buffer('r\r'));
-      readStream.end(new Buffer('\nbaz'));
+      readStream.write(Buffer.from('foo\nba'));
+      readStream.write(Buffer.from('r\r'));
+      readStream.end(Buffer.from('\nbaz'));
     });
 
     context('data contains empty lines and skipEmpty option is true', () => {
@@ -36,9 +36,9 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(new Buffer('foo\nba'));
-        readStream.write(new Buffer('r\r\n\n\r'));
-        readStream.end(new Buffer('\nbaz'));
+        readStream.write(Buffer.from('foo\nba'));
+        readStream.write(Buffer.from('r\r\n\n\r'));
+        readStream.end(Buffer.from('\nbaz'));
       });
     })
   })
@@ -56,8 +56,8 @@ describe('ReadlineTransform', () => {
 
       readStream.pipe(transform).pipe(writeStream);
 
-      readStream.write(new Buffer('foo\r\nbar\n'));
-      readStream.end(new Buffer('\r\nbaz\r\n'));
+      readStream.write(Buffer.from('foo\r\nbar\n'));
+      readStream.end(Buffer.from('\r\nbaz\r\n'));
     });
 
     context('ignoreEndOfBreak is false', () => {
@@ -73,8 +73,8 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(new Buffer('foo\r\nbar\n'));
-        readStream.end(new Buffer('\r\nbaz\r\n'));
+        readStream.write(Buffer.from('foo\r\nbar\n'));
+        readStream.end(Buffer.from('\r\nbaz\r\n'));
       });
     })
 
@@ -91,8 +91,8 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(new Buffer('foo\r\nbar\n'));
-        readStream.end(new Buffer('\r\nbaz\r\n'));
+        readStream.write(Buffer.from('foo\r\nbar\n'));
+        readStream.end(Buffer.from('\r\nbaz\r\n'));
       });
     })
 
@@ -109,9 +109,9 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(new Buffer('foo\n \n'));
-        readStream.write(new Buffer('\n\n'));
-        readStream.write(new Buffer('bar\n'));
+        readStream.write(Buffer.from('foo\n \n'));
+        readStream.write(Buffer.from('\n\n'));
+        readStream.write(Buffer.from('bar\n'));
         readStream.end();
       });
     })
@@ -131,7 +131,7 @@ describe('ReadlineTransform', () => {
 
       readStream.pipe(transform).pipe(writeStream);
 
-      readStream.write(new Buffer('_\nfoo_\nbar_\nbaz_\n_\n'));
+      readStream.write(Buffer.from('_\nfoo_\nbar_\nbaz_\n_\n'));
       readStream.end();
     });
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,7 +19,7 @@ describe('ReadlineTransform', () => {
       readStream.pipe(transform).pipe(writeStream);
 
       readStream.write(Buffer.from('foo\nba'));
-      readStream.write(Buffer.from('r\r'));
+      readStream.write('r\r');
       readStream.end(Buffer.from('\nbaz'));
     });
 
@@ -36,7 +36,7 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(Buffer.from('foo\nba'));
+        readStream.write('foo\nba');
         readStream.write(Buffer.from('r\r\n\n\r'));
         readStream.end(Buffer.from('\nbaz'));
       });
@@ -57,7 +57,7 @@ describe('ReadlineTransform', () => {
       readStream.pipe(transform).pipe(writeStream);
 
       readStream.write(Buffer.from('foo\r\nbar\n'));
-      readStream.end(Buffer.from('\r\nbaz\r\n'));
+      readStream.end('\r\nbaz\r\n');
     });
 
     context('ignoreEndOfBreak is false', () => {
@@ -74,7 +74,7 @@ describe('ReadlineTransform', () => {
         readStream.pipe(transform).pipe(writeStream);
 
         readStream.write(Buffer.from('foo\r\nbar\n'));
-        readStream.end(Buffer.from('\r\nbaz\r\n'));
+        readStream.end('\r\nbaz\r\n');
       });
     })
 
@@ -91,7 +91,7 @@ describe('ReadlineTransform', () => {
 
         readStream.pipe(transform).pipe(writeStream);
 
-        readStream.write(Buffer.from('foo\r\nbar\n'));
+        readStream.write('foo\r\nbar\n');
         readStream.end(Buffer.from('\r\nbaz\r\n'));
       });
     })
@@ -110,7 +110,7 @@ describe('ReadlineTransform', () => {
         readStream.pipe(transform).pipe(writeStream);
 
         readStream.write(Buffer.from('foo\n \n'));
-        readStream.write(Buffer.from('\n\n'));
+        readStream.write('\n\n');
         readStream.write(Buffer.from('bar\n'));
         readStream.end();
       });


### PR DESCRIPTION
- Fix `[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. `
- Apply Buffer and String instances to the stream